### PR TITLE
Chart and CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,14 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - architect/push-to-app-catalog:
+          context: architect
+          executor: app-build-suite
+          name: push-cnpg-app-to-giantswarm-catalog
+          app_catalog: giantswarm-catalog
+          app_catalog_test: giantswarm-test-catalog
+          chart: cloudnative-pg
+          # Trigger job on git tag.
+          filters:
+            tags:
+              only: /^v.*/

--- a/helm/cloudnative-pg/.kube-linter.yaml
+++ b/helm/cloudnative-pg/.kube-linter.yaml
@@ -1,0 +1,3 @@
+checks:
+  doNotAutoAddDefaults: true
+  addAllBuiltIn: false

--- a/helm/cloudnative-pg/Chart.yaml
+++ b/helm/cloudnative-pg/Chart.yaml
@@ -10,4 +10,6 @@ version: 0.0.0-dev
 annotations:
   application.giantswarm.io/team: "shield"
   config.giantswarm.io/version: 1.x.x
-dependencies: []
+dependencies:
+  - name: cloudnative-pg
+    version: 0.20.2

--- a/helm/cloudnative-pg/Chart.yaml
+++ b/helm/cloudnative-pg/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.0.1
 name: cloudnative-pg
 description: A Giant Swarm app for deploying CloudNative PostgreSQL.
 home: https://github.com/giantswarm/cloudnative-pg-app
-# icon: https://s.giantswarm.io/app-icons/cloudnative-pg/icon-light.svg
+icon: https://s.giantswarm.io/app-icons/cloudnative-pg/icon-light.svg
 sources:
   - https://github.com/cloudnative-pg/charts
 version: 0.0.0-dev

--- a/helm/cloudnative-pg/Chart.yaml
+++ b/helm/cloudnative-pg/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.0.1
 name: cloudnative-pg
 description: A Giant Swarm app for deploying CloudNative PostgreSQL.
 home: https://github.com/giantswarm/cloudnative-pg-app
-icon: https://s.giantswarm.io/app-icons/cloudnative-pg/icon-light.svg
+# icon: https://s.giantswarm.io/app-icons/cloudnative-pg/icon-light.svg
 sources:
   - https://github.com/cloudnative-pg/charts
 version: 0.0.0-dev

--- a/helm/cloudnative-pg/values.schema.json
+++ b/helm/cloudnative-pg/values.schema.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        }
+    }
+}

--- a/helm/cloudnative-pg/values.yaml
+++ b/helm/cloudnative-pg/values.yaml
@@ -5,3 +5,12 @@ image:
   name: giantswarm/cloudnative-pg
   tag: v0.0.1
   pullPolicy: IfNotPresent
+
+cloudnative-pg:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi


### PR DESCRIPTION
This PR:

- disables kube-linter because it sees the licenses in some subchart files and breaks
- adds helm values schema
- adds the subchart as a dependency
- sets resources
- pushes to the GS catalog because app-operator breaks trying to get a draughtsman configmap using control-plane for this app for some reason

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
