### PR TITLE
Add CNP and enable podmonitor for operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CiliumNetworkPolicy.
+- Enable PodMonitor for operator metrics.
+- Enable Grafana dashboard.
+
 ## [0.0.2] - 2024-04-30
 
 ### Changed

--- a/helm/cloudnative-pg/templates/cilium-network-policy.yaml
+++ b/helm/cloudnative-pg/templates/cilium-network-policy.yaml
@@ -14,13 +14,6 @@ spec:
     # Allow egress to Kubernetes API server.
     - toEntities:
         - kube-apiserver
-    # Allow DNS.
-    - toEntities:
-        - cluster
-      toPorts:
-        - ports:
-            - port: "53"
-            - port: "1053"
   ingress:
     # Allow scraping metrics.
     - fromEntities:

--- a/helm/cloudnative-pg/templates/cilium-network-policy.yaml
+++ b/helm/cloudnative-pg/templates/cilium-network-policy.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.ciliumNetworkPolicy.enabled }}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "cloudnative-pg.fullname" . }}-cnp
+  labels:
+    {{- include "cloudnative-pg.labels" . | nindent 4 }}
+  # annotations:
+  #   ignore-check.kube-linter.io/dangling-networkpolicy: "The podselector value, app.kubernetes.io/managed-by:trivy-operator is inherited from parent repository."
+spec:
+  endpointSelector:
+    matchLabels:
+       {{- include "cloudnative-pg.selectorLabels" . | nindent 6 }}
+  egress:
+    # Allow egress to Kubernetes API server.
+    - toEntities:
+        - kube-apiserver
+    # Allow DNS.
+    - toEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "53"
+            - port: "1053"
+  ingress:
+    - fromEntities:
+      - cluster
+      toPorts:
+      - ports:
+        - port: "8080"
+{{ end }}

--- a/helm/cloudnative-pg/templates/cilium-network-policy.yaml
+++ b/helm/cloudnative-pg/templates/cilium-network-policy.yaml
@@ -6,8 +6,6 @@ metadata:
   name: {{ include "cloudnative-pg.fullname" . }}-cnp
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
-  # annotations:
-  #   ignore-check.kube-linter.io/dangling-networkpolicy: "The podselector value, app.kubernetes.io/managed-by:trivy-operator is inherited from parent repository."
 spec:
   endpointSelector:
     matchLabels:
@@ -24,6 +22,7 @@ spec:
             - port: "53"
             - port: "1053"
   ingress:
+    # Allow scraping metrics.
     - fromEntities:
       - cluster
       toPorts:

--- a/helm/cloudnative-pg/values.yaml
+++ b/helm/cloudnative-pg/values.yaml
@@ -11,6 +11,12 @@ cloudnative-pg:
     podMonitorEnabled: true
     podMonitorAdditionalLabels:
       application.giantswarm.io/team: shield
+    grafanaDashboard:
+      create: true
+      labels:
+        app.giantswarm.io/kind: "dashboard"
+      annotations:
+        k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/public"
   resources:
     limits:
       cpu: 250m

--- a/helm/cloudnative-pg/values.yaml
+++ b/helm/cloudnative-pg/values.yaml
@@ -7,6 +7,10 @@ image:
   pullPolicy: IfNotPresent
 
 cloudnative-pg:
+  monitoring:
+    podMonitorEnabled: true
+    podMonitorAdditionalLabels:
+      application.giantswarm.io/team: shield
   resources:
     limits:
       cpu: 250m
@@ -18,3 +22,6 @@ cloudnative-pg:
 vpa:
   enabled: true
   containerPolicies: {}
+
+ciliumNetworkPolicy:
+  enabled: true

--- a/vendir.yml
+++ b/vendir.yml
@@ -10,12 +10,3 @@ directories:
     includePaths:
       - charts/cloudnative-pg/**/*
     newRootPath: charts/cloudnative-pg
-- path: helm/cloudnative-pg/charts/dashboards
-  contents:
-  - path: .
-    git:
-      url: https://github.com/cloudnative-pg/grafana-dashboards
-      ref: cluster-v0.0.2
-    includePaths:
-      - charts/cluster/**/*
-    newRootPath: charts/cluster


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30093

This PR:

- adds a cilium network policy
- enables the upstream podmonitor for the cpng operator
- enables the upstream dashboard in a future upstream release

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
