### PR TITLE
Add DNS block to CNP

### DIFF
--- a/helm/cloudnative-pg/templates/cilium-network-policy.yaml
+++ b/helm/cloudnative-pg/templates/cilium-network-policy.yaml
@@ -109,6 +109,14 @@ spec:
       toPorts:
         - ports:
             - port: "5432"
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: coredns
+            k8s:io.kubernetes.pod.namespace: kube-system
+        toPorts:
+        - ports:
+          - port: "1053"
+            protocol: ANY
     # Allow CNPG management controller to access the API server.
     - toEntities:
       - kube-apiserver

--- a/helm/cloudnative-pg/templates/cilium-network-policy.yaml
+++ b/helm/cloudnative-pg/templates/cilium-network-policy.yaml
@@ -43,6 +43,35 @@ spec:
       - ports:
         - port: "8080"
 ---
+# This policy targets all pods that belong to any CNPG-managed Postgres cluster (instance, init, join).
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: {{ include "cloudnative-pg.fullname" . }}-db-dns
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: cnpg.io/cluster
+        operator: Exists
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: coredns
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: k8s-dns-node-cache
+      toPorts:
+        - ports:
+            - port: "1053"
+              protocol: UDP
+            - port: "1053"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+---
 # This policy targets the Postgres database instance pods managed by CNPG.
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideNetworkPolicy
@@ -109,23 +138,6 @@ spec:
       toPorts:
         - ports:
             - port: "5432"
-    - toEndpoints:
-        - matchLabels:
-            io.kubernetes.pod.namespace: kube-system
-            k8s-app: coredns
-        - matchLabels:
-            io.kubernetes.pod.namespace: kube-system
-            k8s-app: k8s-dns-node-cache
-      toPorts:
-        - ports:
-            - port: "1053"
-              protocol: UDP
-            - port: "1053"
-              protocol: TCP
-            - port: "53"
-              protocol: UDP
-            - port: "53"
-              protocol: TCP
     # Allow CNPG management controller to access the API server.
     - toEntities:
       - kube-apiserver

--- a/helm/cloudnative-pg/templates/cilium-network-policy.yaml
+++ b/helm/cloudnative-pg/templates/cilium-network-policy.yaml
@@ -111,12 +111,21 @@ spec:
             - port: "5432"
     - toEndpoints:
         - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
             k8s-app: coredns
-            k8s:io.kubernetes.pod.namespace: kube-system
-        toPorts:
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: k8s-dns-node-cache
+      toPorts:
         - ports:
-          - port: "1053"
-            protocol: ANY
+            - port: "1053"
+              protocol: UDP
+            - port: "1053"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
     # Allow CNPG management controller to access the API server.
     - toEntities:
       - kube-apiserver


### PR DESCRIPTION
Some namespaces have a default allow dns rule, others don't. This covers the ones that don't.
