### PR TITLE
Rotate operator-managed certs 16 days before expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rotate operator-managed certificates 16 days before their expiration, instead of 7 days.
+
 ## [0.0.5] - 2024-06-06
 
 ### Added

--- a/helm/cloudnative-pg/values.yaml
+++ b/helm/cloudnative-pg/values.yaml
@@ -7,6 +7,10 @@ image:
   pullPolicy: IfNotPresent
 
 cloudnative-pg:
+  config:
+    data:
+      # Rotate certificates managed by the CNPG operator this many days before their expiration.
+      EXPIRING_CHECK_THRESHOLD: "16"
   image:
     repository: gsoci.azurecr.io/giantswarm/cloudnative-pg
   monitoring:


### PR DESCRIPTION
This PR:

- causes the CNPG operator to renew the self-signed certs it uses for e.g. webhook configurations before our oncallers are paged for the certificates expiring. 

The default threshold is 7 days, but we get notified earlier than that (at 14 days) to avoid customer outages. This allows 2 days for the operator to renew the cert before a human will be paged to intervene.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
