### PR TITLE
grafana dashboard: load it to Shared Org (public) organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- grafana dashboard: load it to `Shared Org` (public) organization
+
 ## [0.0.6] - 2024-08-20
 
 ### Changed

--- a/helm/cloudnative-pg/values.yaml
+++ b/helm/cloudnative-pg/values.yaml
@@ -22,7 +22,7 @@ cloudnative-pg:
       labels:
         app.giantswarm.io/kind: "dashboard"
       annotations:
-        k8s-sidecar-target-directory: "/var/lib/grafana/dashboards/public"
+        observability.giantswarm.io/organization: "Shared Org"
   resources:
     limits:
       cpu: 250m


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3696

This PR updates the dashboard for the multi-tenant dashboards provisioning.

Note: the new annotations will work on CAPI clusters, but not on vintage clusters. I guess it's OK for this app, because AFAIK it's not meant to deploy on vintage, right?

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
