### PR TITLE
Fix typo in proxmox collection name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,10 @@ workflows:
             only: /^v.*/
 
     - architect/push-to-app-collection:
-        name: promox-app-collection
+        name: proxmox-app-collection
         context: architect
         app_name: cloudnative-pg
-        app_collection_repo: promox-app-collection
+        app_collection_repo: proxmox-app-collection
         requires:
         - push-cnpg-app-to-control-plane-catalog
         filters:


### PR DESCRIPTION
This PR:

- changes `promox` to `proxmox`

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
