### PR TITLE
chore: drop inline vendir customManager

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,14 +6,6 @@
     "github>giantswarm/renovate-presets:disable-upstream-charts.json5"
   ],
   "automerge": true,
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)vendir\\.yml$"],
-      "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\n]+)\\n\\s+ref: (?<currentValue>[^\\n]+)"],
-      "versioningTemplate": "regex:^cloudnative-pg-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
-    }
-  ],
   "packageRules": [
     {
       "description": "Automerge architect updates",
@@ -30,7 +22,8 @@
       "matchFileNames": ["vendir.yml"],
       "branchPrefix": "renovate/vendir/",
       "prCreation": "approval",
-      "groupName": "cloudnative-pg-upstream"
+      "groupName": "cloudnative-pg-upstream",
+      "versioning": "regex:^cloudnative-pg-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
The vendir `customManager` and its matching `packageRule` (`branchPrefix`, `prCreation`) are now provided by `giantswarm/renovate-presets:default.json5` (renovate-presets#99). The inline copy is a duplicate once that PR lands.

The repo-specific `groupName` and non-semver `versioning` override (`regex:^cloudnative-pg-v\d+\.\d+\.\d+$`) are kept in the vendir `packageRule`. The versioning override moves from `versioningTemplate` on the customManager to `versioning` on the packageRule.

Merge after renovate-presets#99.