### PR TITLE
fix: set appVersion to 1.29.1 and add CHANGELOG entry for v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update cloudnative-pg to v1.29.1 (upstream chart v0.28.2).
 - Limit the namespaces watched by the operator to those where we currently expect Giant Swarm postgresql clusters.
 - Migrate chart metadata annotations to OCI-compatible format.
 

--- a/helm/cloudnative-pg/Chart.yaml
+++ b/helm/cloudnative-pg/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.27.1
+appVersion: 1.29.1
 name: cloudnative-pg
 description: A Giant Swarm app for deploying CloudNative PostgreSQL.
 home: https://github.com/giantswarm/cloudnative-pg-app


### PR DESCRIPTION
## Changes

- `helm/cloudnative-pg/Chart.yaml`: bump `appVersion` from `1.27.1` to `1.29.1` to match the dependency already on main (upstream chart v0.28.2, CNPG 1.29.1, landed in #145/#146).
- `CHANGELOG.md`: add the missing upgrade entry under `[Unreleased]` so the release tooling can cut v0.0.14.

## Why

`appVersion` was not updated when Renovate bumped the upstream chart dependency. The CHANGELOG was also missing the CNPG version bump entry. Both are required before cutting the v0.0.14 release.

The dependency (`cloudnative-pg: 0.28.2`) has been on `main` since 2026-05-12. No other changes to the chart values or templates are needed — glean's `WATCH_NAMESPACE` is overridden via konfiguration and survives the new chart default.

## Upgrade path

Direct 1.27.1 → 1.29.1. CNPG 1.28 and 1.29 release notes carry no breaking changes for our setup. After this merges, a dev-tag test on glean is planned before cutting the final release.