### PR TITLE
fix(renovate): disable major updates for postgresql-cnpg catalog images

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,6 +24,12 @@
       "matchPackageNames": ["gsoci.azurecr.io/giantswarm/postgresql-cnpg"],
       "automerge": false,
       "groupName": "postgresql-cnpg catalog images"
+    },
+    {
+      "matchFileNames": ["helm/cloudnative-pg/values.yaml"],
+      "matchPackageNames": ["gsoci.azurecr.io/giantswarm/postgresql-cnpg"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a `packageRules` entry that disables major-version updates for `gsoci.azurecr.io/giantswarm/postgresql-cnpg` in `values.yaml`.

## Why

The existing custom regex manager has no major-version constraint. Renovate treats all `clusterImageCatalog.images` entries as the same dep and proposes updating every tag to the latest available (18.4). This produced PR #161, which would have replaced `tag: "15.18"` / `"16.14"` / `"17.10"` with `"18.4"` — rolling existing PostgreSQL clusters to the wrong major-version image.

Each catalog entry must only receive patch/minor bumps within its declared PG major. New major versions require a deliberate, hand-authored entry in `values.yaml`.

## Closes

Supersedes #161 (close that PR after this merges and Renovate re-runs).