### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ workflows:
         app_catalog: control-plane-catalog
         app_catalog_test: control-plane-test-catalog
         chart: cloudnative-pg
-          # Trigger job on git tag.
+        override_app_version: false
+        # Trigger job on git tag.
         filters:
           tags:
             only: /^v.*/
@@ -29,7 +30,8 @@ workflows:
         app_catalog_test: giantswarm-operations-platform-test-catalog
         ct_config: ".circleci/ct-config.yaml"
         chart: cloudnative-pg
-          # Trigger job on git tag.
+        override_app_version: false
+        # Trigger job on git tag.
         filters:
           tags:
             only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [0.1.0] - 2026-06-04
 
 ### Added


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
